### PR TITLE
Install icon to hicolor icon theme

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -56,6 +56,7 @@
                 "icotool -x Ghidra/RuntimeScripts/Windows/support/ghidra.ico --index=8",
                 "cp -r ghidra_*_FLATPAK /app/lib/ghidra",
                 "install -Dm644 ghidra_8_256x256x32.png /app/share/icons/org.ghidra_sre.Ghidra.png",
+                "install -Dm644 ghidra_8_256x256x32.png /app/share/icons/hicolor/256x256/apps/org.ghidra_sre.Ghidra.png",
                 "install -Dm644 org.ghidra_sre.Ghidra.desktop /app/share/applications/org.ghidra_sre.Ghidra.desktop",
                 "install -Dm644 org.ghidra_sre.Ghidra.metainfo.xml /app/share/metainfo/org.ghidra_sre.Ghidra.metainfo.xml",
                 "install -Dm755 ghidra.sh /app/bin/ghidra",


### PR DESCRIPTION
Installing icons directly under `XDG_DATA_DIRS/icons` and in an icon theme folder is quite unusual, icons will not be included in `icon-theme.cache`, and applications launcher might not display the icons (e.g. fuzzel).