### PR TITLE
Use archived tarball

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -58,7 +58,7 @@
                 {
                     "type": "archive",
                     "sha256": "c1f18cdb12e2e1c0313e7becf7f0387226937ac67ad6c6e5056fa889229f969a",
-                    "url": "https://ghidra-sre.org/ghidra_9.2.4_PUBLIC_20210427.zip",
+                    "url": "http://web.archive.org/web/20210629191145/https://ghidra-sre.org/ghidra_9.2.4_PUBLIC_20210427.zip",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest",


### PR DESCRIPTION
Upstream removed the release tarball we're still using for now, so
download the version from the Wayback Machine until we can upgrade.