### PR TITLE
Fix IN-VM gdb local debugging

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.ghidra_sre.Ghidra",
     "default-branch": "stable",
-    "runtime": "org.freedesktop.Platform",
+    "runtime": "org.freedesktop.Sdk",
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
@@ -14,6 +14,7 @@
         "--socket=x11",
         "--socket=pulseaudio",
         "--device=dri",
+        "--allow=devel",
         "--filesystem=home",
         "--env=PATH=/usr/bin:/app/bin:/app/jdk/bin",
         "--env=JAVA_HOME=/app/jdk"


### PR DESCRIPTION
Include gdb in the Flatpak by using the SDK as runtime, and allow ptrace
access with the devel option.

Closes: #25