### PR TITLE
Update to OpenJDK 17

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -5,7 +5,7 @@
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk11"
+        "org.freedesktop.Sdk.Extension.openjdk17"
     ],
     "command": "ghidra",
     "finish-args": [
@@ -24,7 +24,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk11/installjdk.sh"
+                "/usr/lib/sdk/openjdk17/installjdk.sh"
             ]
         },
         {
@@ -52,7 +52,7 @@
                 "cp dex2jar/lib/dex-*.jar dependencies/flatRepo",
                 "cp -r ghidra-data/FunctionID dependencies/fidb",
                 "sed -i 's/^application.release.name=DEV$/application.release.name=FLATPAK/' Ghidra/application.properties",
-                "source /usr/lib/sdk/openjdk11/enable.sh && gradle buildGhidra",
+                "source /usr/lib/sdk/openjdk17/enable.sh && gradle buildGhidra",
                 "unzip build/dist/ghidra_*_FLATPAK_*_linux_*.zip",
                 "icotool -x Ghidra/RuntimeScripts/Windows/support/ghidra.ico --index=8",
                 "cp -r ghidra_*_FLATPAK /app/lib/ghidra",


### PR DESCRIPTION
OpenJDK 17 is the new LTS version of OpenJDK, and will be required by newer versions of Ghidra, so update to that.