### PR TITLE
Update Ghidra-data external data checker

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -138,8 +138,11 @@
                     "commit": "7d843ec229d43c2d1a8178aaa892be90e37e95a2",
                     "dest": "ghidra-data",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^Ghidra_([\\d.]+)_build$"
+                        "type": "json",
+                        "url": "https://api.github.com/repos/NationalSecurityAgency/ghidra-data/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": ".tag_name | sub(\"^Ghidra_\"; \"\")",
+                        "timestamp-query": ".published_at"
                     }
                 },
                 "gradle-dependencies.json"


### PR DESCRIPTION
Updates to the new JSON style. And also tag names that seems to have been updated on Ghidra data repo.
Not updating the tag in this pull request as the checker should do it automatically.