### PR TITLE
Update to OpenJDK 21

### DIFF
--- a/generate-deps.sh
+++ b/generate-deps.sh
@@ -14,7 +14,7 @@ get_sdk()
 
 verify_jdk()
 {
-	JDK=$(flatpak info $SDK | grep "Ref:" | sed -e 's,Ref: runtime/,,' -e 's,org.freedesktop.Sdk,org.freedesktop.Sdk.Extension.openjdk17,')
+	JDK=$(flatpak info $SDK | grep "Ref:" | sed -e 's,Ref: runtime/,,' -e 's,org.freedesktop.Sdk,org.freedesktop.Sdk.Extension.openjdk21,')
 	OUTPUT=$(flatpak info $JDK 2>&1)
 	if [ $? -ne 0 ] ; then
 		echo "$JDK extension missing for runtime $SDK"
@@ -28,7 +28,7 @@ verify_jdk
 rm -rf _deps_build
 git clone https://github.com/NationalSecurityAgency/ghidra.git -b stable _deps_build
 cd _deps_build
-echo "source /usr/lib/sdk/openjdk17/enable.sh && gradle -g gradle-cache -I gradle/support/fetchDependencies.gradle init && rm -rf gradle-cache && gradle -g gradle-cache --info --console plain buildGhidra > gradle-log.txt" | flatpak run --share=network --filesystem=`pwd` --devel $SDK
+echo "source /usr/lib/sdk/openjdk21/enable.sh && gradle -g gradle-cache -I gradle/support/fetchDependencies.gradle init && rm -rf gradle-cache && gradle -g gradle-cache --info --console plain buildGhidra > gradle-log.txt" | flatpak run --share=network --filesystem=`pwd` --devel $SDK
 wget https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/gradle/flatpak-gradle-generator.py
 chmod +x flatpak-gradle-generator.py
 ./flatpak-gradle-generator.py gradle-log.txt ../gradle-dependencies.json --destdir dependencies/flatRepo --arches x86_64,aarch64

--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -4,7 +4,7 @@
     "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk17"
+        "org.freedesktop.Sdk.Extension.openjdk21"
     ],
     "command": "ghidra",
     "finish-args": [
@@ -23,7 +23,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk17/installjdk.sh"
+                "/usr/lib/sdk/openjdk21/installjdk.sh"
             ]
         },
         {
@@ -52,7 +52,7 @@
                 "cp ghidra-data/lib/*.jar dependencies/flatRepo",
                 "cp -r ghidra-data/FunctionID dependencies/fidb",
                 "sed -i 's/^application.release.name=DEV$/application.release.name=FLATPAK/' Ghidra/application.properties",
-                "source /usr/lib/sdk/openjdk17/enable.sh && gradle buildGhidra",
+                "source /usr/lib/sdk/openjdk21/enable.sh && gradle buildGhidra",
                 "unzip build/dist/ghidra_*_FLATPAK_*_linux_*.zip",
                 "icotool -x Ghidra/RuntimeScripts/Windows/support/ghidra.ico --index=8",
                 "cp -r ghidra_*_FLATPAK /app/lib/ghidra",


### PR DESCRIPTION
As it is required by newer versions of Ghidra, see: https://github.com/NationalSecurityAgency/ghidra/issues/6854

We'll try this separately. If it fails to build, we'll try and do that as part of:
https://github.com/flathub/org.ghidra_sre.Ghidra/pull/91