### PR TITLE
Bump runtime version

### DIFF
--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.ghidra_sre.Ghidra",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk21"


### PR DESCRIPTION
Bump runtime version to one that has support for more platforms in included GDB.

Freedesktop SDK 24.08.12 added compile-time flags to GDB to allow debugging of more architectures, which would allow use of Flatpak Ghidra to debug those architectures as it, to my understanding, uses the GDB included in the runtime.