### PR TITLE
Use script to extract "fetchDependencies.gradle" deps

### DIFF
--- a/generate-deps.sh
+++ b/generate-deps.sh
@@ -34,15 +34,30 @@ get_ghidra_version()
 	echo $TAG
 }
 
+get_ghidra_data_version()
+{
+	TAG=$(jq -r '.["modules"].[] | select(.name=="ghidra")["sources"][] | select(.url=="https://github.com/NationalSecurityAgency/ghidra-data.git")["tag"]' org.ghidra_sre.Ghidra.json 2> /dev/null)
+	if [ -z "$TAG" ] ; then
+		echo "Could not extract current data release tag from org.ghidra_sre.Ghidra.json"
+		exit 1
+	fi
+	echo $TAG | sed 's/Ghidra_//'
+}
+
 SDK=$(get_sdk)
 verify_jdk
 TAG=$(get_ghidra_version)
+DATA_VERSION=$(get_ghidra_data_version)
 
 rm -rf _deps_build
+echo "Checking out Ghidra $VERSION"
 git clone https://github.com/NationalSecurityAgency/ghidra.git -b "$TAG" _deps_build
 cd _deps_build
+echo "Generating fetched gradle dependencies (ghidra-data v$DATA_VERSION)"
+../gradle-fetched-deps-generator.py gradle/support/fetchDependencies.gradle ../gradle-fetched-dependencies.json --version "$DATA_VERSION"
 echo "Generating deps log in Sdk $SDK"
 echo "source /usr/lib/sdk/openjdk21/enable.sh && gradle -g gradle-cache --init-script gradle/support/fetchDependencies.gradle && rm -rf gradle-cache && gradle -g gradle-cache --info --console plain buildGhidra > gradle-log.txt" | flatpak run --share=network --filesystem=`pwd` --devel $SDK
 wget https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/gradle/flatpak-gradle-generator.py
 chmod +x flatpak-gradle-generator.py
+echo "Generating gradle dependencies"
 ./flatpak-gradle-generator.py gradle-log.txt ../gradle-dependencies.json --destdir dependencies/flatRepo --arches x86_64,aarch64

--- a/gradle-fetched-dependencies.json
+++ b/gradle-fetched-dependencies.json
@@ -1,0 +1,285 @@
+[
+
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/lib/java-sarif-2.1-modified.jar",
+       "sha256": "7f736566494756d271aa5e4b1af6c89dc50d074ab1c6374a47df822264226b01",
+       "dest": "dependencies/flatRepo"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/Debugger/dbgmodel.tlb",
+       "sha256": "8cf5f3a2eb81160aa349056a5ca4c2c726b1b6e98bf3097cd4135147163343c7",
+       "dest": "dependencies/Debugger-agent-dbgeng/"
+   },
+   {
+       "type": "file",
+       "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android4me/AXMLPrinter2.jar",
+       "sha256": "00ed038eb6abaf6ddec8d202a3ed7a81b521458f4cd459948115cfd02ff59d6d",
+       "dest": "dependencies/flatRepo"
+   },
+   {
+       "type": "file",
+       "url": "https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.18/yajsw-stable-13.18.zip",
+       "sha256": "50b34e9817c54b2970fa511ff4584f6556c179f69833aa8b9b1ff6485b61684f",
+       "dest": "dependencies/GhidraServer"
+   },
+   {
+       "type": "file",
+       "url": "https://ftp.postgresql.org/pub/source/v15.13/postgresql-15.13.tar.gz",
+       "sha256": "afdc22b0a6e5bec7b65723756b90d44ea911e61b2f7b01c4dc5524ab813b4d89",
+       "dest": "dependencies/BSim"
+   },
+   {
+       "type": "file",
+       "url": "https://sourceforge.net/projects/pydev/files/pydev/PyDev%209.3.0/PyDev%209.3.0.zip",
+       "sha256": "45398edf2adb56078a80bc88a919941578f0c0b363efbdd011bfd158a99b112e",
+       "dest": "dependencies/GhidraDev"
+   },
+   {
+       "type": "file",
+       "url": "https://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip",
+       "sha256": "81b7d19d57c4a3009f4761699a72e8d642b5e1d9251d2bb98df438b1e28f8ba9",
+       "dest": "dependencies/GhidraDev"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2012_x64.fidb",
+       "sha256": "d4e98ab3f790b831793218430bba0d8b24a5fbf4da65b0c1ffa8cb0cfbeb0cdc",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2012_x86.fidb",
+       "sha256": "a490ed7e2ed21e587459feaeace7036b7ede4ce84e72e10dfd8c57434a6918b6",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2015_x64.fidb",
+       "sha256": "e04e9e40f9ecb601c85f4d84ed9bf66b45363be1d1e82c162e4c9902b8cb508f",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2015_x86.fidb",
+       "sha256": "b66ee696653e2ed365919deaaef885103120c792e22e79af70d1209d7e1d8644",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2017_x64.fidb",
+       "sha256": "d5fa5f697298174fa53d247d3599e6a12884605ad181c7b954e2380ec1f0bd89",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2017_x86.fidb",
+       "sha256": "d389cb8d76ff4a59ca35f891b8521c72ad5f0df96e253973a2d21a8614a4cc81",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2019_x64.fidb",
+       "sha256": "150007796fc36a4069660ad62449aadaaf3dd11b3864a5ef21e79831c9ce9118",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vs2019_x86.fidb",
+       "sha256": "eb630a36faa586a371eb734dc0bbd8d13ccaef697f3db5872596358f3dd2432a",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vsOlder_x64.fidb",
+       "sha256": "8c3b51f4660cd27e1a0d610a9f3f2d5fbc833a66ac9ee4393ee2f2481e855866",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.2/FunctionID/vsOlder_x86.fidb",
+       "sha256": "98605c6b6b9214a945d844e41c85860d54649a45bca7873ef6991c0e93720787",
+       "dest": "dependencies/fidb"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/ee/01/1ed1d482960a5718fd99c82f6d79120181947cfd4667ec3944d448ed44a3/protobuf-6.31.0-py3-none-any.whl",
+       "sha256": "6ac2e82556e822c17a8d23aa1190bbc1d06efb9c261981da95c71c9da09e9e23",
+       "dest": "dependencies/Debugger-rmi-trace/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz",
+       "sha256": "6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c",
+       "dest": "dependencies/Debugger-rmi-trace/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl",
+       "sha256": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
+       "dest": "dependencies/Debugger-rmi-trace/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
+       "sha256": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248",
+       "dest": "dependencies/Debugger-rmi-trace/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/ce/78/91db67e7fe1546dc8b02c38591b7732980373d2d252372f7358054031dd4/Pybag-2.2.12-py3-none-any.whl",
+       "sha256": "eda5ee6c4e873902981b7f525b42a02428b87c7368df2c5bdfe1ded0e6884126",
+       "dest": "dependencies/Debugger-agent-dbgeng/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/d0/dd/b28df50316ca193dd1275a4c47115a720796d9e1501c1888c4bfa5dc2260/capstone-5.0.1-py3-none-win_amd64.whl",
+       "sha256": "1bfa5c81e6880caf41a31946cd6d2d069c048bcc22edf121254b501a048de675",
+       "dest": "dependencies/Debugger-agent-dbgeng/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/50/8f/518a37381e55a8857a638afa86143efa5508434613541402d20611a1b322/comtypes-1.4.1-py3-none-any.whl",
+       "sha256": "a208a0e3ca1c0a5362735da0ff661822801dce87312b894d7d752add010a21b0",
+       "dest": "dependencies/Debugger-agent-dbgeng/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/83/1c/25b79fc3ec99b19b0a0730cc47356f7e2959863bf9f3cd314332bddb4f68/pywin32-306-cp312-cp312-win_amd64.whl",
+       "sha256": "37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e",
+       "dest": "dependencies/Debugger-agent-dbgeng/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl",
+       "sha256": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/76/be/b37005bec457b94eaaf637a663073b7c5df70113fd4ae4865f6e386c612f/jpype1-1.5.2-cp313-cp313-macosx_10_13_universal2.whl",
+       "sha256": "4acb098cb1698b14b6e5c79e275f4c70dcc01b0fb93425f206d0a5e380e43c66",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/20/a3/00a265d424f7d47e0dc547df2320225ce0143fec671faf710def41404b8c/jpype1-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+       "sha256": "c08480c7d18125664a12bf0a244b96b49c05105306b65937dbefeb05ab4b2847",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/6d/d0/191db2e9ab6ae7029368a488c9d88235966843b185aba7925e54aa0c0013/jpype1-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+       "sha256": "42fe8db66ad4e5c66f637f5c4de82fca880ba696104e1f4a7e575885923dead8",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/e3/b7/e1787633b41d609320b41d0dd87fe3118598210609e4e3f6cef93cfcef40/jpype1-1.5.2-cp313-cp313-win_amd64.whl",
+       "sha256": "2b96365f1302df2fb3c6ad73117d6fe450a55b7550fd7fecadac3cec5bc7117c",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/8d/e4/0c27352e8222dcc0e3ce44b298015072d2057d08dd353541c980a31d26c9/jpype1-1.5.2-cp312-cp312-macosx_10_9_universal2.whl",
+       "sha256": "1e1db9ac909ad2ae0e40b04c2aa88cb14250d5245d69715561507681f2b08b2f",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/fa/4c/e0200a6e3fed5cda79e926c2a8a610676f04948f89d7e38d93c7d4b21be9/jpype1-1.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+       "sha256": "994fb7b319b453f77ad4b6aff01e0dd4180ea74a6fe5a031e4e9db92dbe95376",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/74/f3/1cd4332076ed0421e703412f47f15f43af170809435c57ba3162edc80d4b/jpype1-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+       "sha256": "b5b1fb2b430a50f081ea0ee24d19232ae0d03dbfe3dd076ec5f8ae42b30a656f",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/74/dd/7408d4beae755de6fcd07c76b2f0bacabc0461b43fba83811c1f7c22440e/jpype1-1.5.2-cp312-cp312-win_amd64.whl",
+       "sha256": "c7b1c2d76d211cab60be16505d32a6b3c9fffc51ce79c68e81a3d48e5effff2d",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/35/a0/638186a75026a02286041e4a0449b1dff799a3914dc1c0716ef9b9367b73/jpype1-1.5.2-cp311-cp311-macosx_10_9_universal2.whl",
+       "sha256": "c9f6ab8dd284c16e2617a697d54c3d0304b08020a37386ed96103a129391a2d9",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/0e/78/95db2eb3c8a7311ee08a2c237cea24828859db6a6cb5e901971d3f5e49da/jpype1-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+       "sha256": "a54a771ee56260f98e5b9a77455084e4a48061967de13dabf628bdba9c8122e0",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/0b/7d/9fdbbc1a574be43f9820735ca8df0caf8b159856201d9b21fd73932342bc/jpype1-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+       "sha256": "b900e154826a076118d074166596f1d817e113e07084bf0c9c43d8064a86ab77",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/0e/b9/4dfb38a7f4efb21f71df7344944a8d9a23e30d0503574e455af6ce4f1a56/jpype1-1.5.2-cp311-cp311-win_amd64.whl",
+       "sha256": "0a0d18d4384b3df2e55282545737dfcf18c604504f1382ad14f880bef960f265",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/c7/f2/b2efcad1ea5a541f125218e4eb1529ebb8ca18941264c879f3e89a36dc35/jpype1-1.5.2-cp310-cp310-macosx_10_9_universal2.whl",
+       "sha256": "7b2da98c142812ca40a18a735b33e47c6511b03debf1e979630f4cf473b68a87",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/c0/c6/63538d160c17e837f62d29ba4163bc444cef08c29cd3f3b8090691c1869c/jpype1-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+       "sha256": "fcfc5c1d45d6b108800d172ea817bda585db7f1646d6a98d14da9aca66e0eb44",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/97/0a/cbe03759331c640aa5862f974028122a862b08935a0b11b8fa6f6e46c26b/jpype1-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+       "sha256": "cdca93cc74f8db1f604d2ea6adb764dec4dec68528f1ee68308fa3d524095739",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/22/18/0a51845ca890ffdc72f4d71a0c2be334b887c5bb6812207efe5ad45afcb3/jpype1-1.5.2-cp310-cp310-win_amd64.whl",
+       "sha256": "924b0a0cf93d3dddb3f79286fbe40f8c901c78ed61216edbe108666234df43e0",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/05/71/590b2a91b43763aa27eac2c63803542a2878a4d8c600b81aa694d3fde919/jpype1-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl",
+       "sha256": "8b75d33e93a3bc6543ddf97c24ee0adb5a86a69fb67f0e4f4fa1c8c3970bbf98",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/77/6b/130fb6d0c43976b4e129c6bc19daf0e25c42fc38c5096ed92c4105bfd2c4/jpype1-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+       "sha256": "ea21bca4cece752cd3ee88fcd62ce8f444feac8dc7244475fdb9c0e8712e07ea",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/77/91/f08a719461a390b48d9096b50f1f4a49ee281007ec192e51073090d3d8b7/jpype1-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+       "sha256": "54744265ef36665d110d139a4b81d10532694c6077b23ef60f3609feadc22d30",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/e5/cf/344e1f81f1e8c651ec23dfa9fe4b91f6e1d699b36f610a547ba85ee7fb16/jpype1-1.5.2-cp39-cp39-win_amd64.whl",
+       "sha256": "68e1d118200fc46f4ea4bf20900081587ec04de484037c997b0a3b7c5eb71fe3",
+       "dest": "dependencies/PyGhidra/"
+   },
+   {
+       "type": "file",
+       "url": "https://files.pythonhosted.org/packages/bd/68/47fa634cbd0418cbca86355e9421425f5892ee994f7338106327e49f9117/jpype1-1.5.2.tar.gz",
+       "sha256": "74a42eccf21d30394c1832aec3985a14965fa5320da087b65029d172c0cec43b",
+       "dest": "dependencies/PyGhidra/"
+   }
+]

--- a/gradle-fetched-deps-generator.py
+++ b/gradle-fetched-deps-generator.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import re
+
+def extract_dependencies_to_table(in_file, out_file, version):
+    with open(in_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Isolate the entire ext.deps block
+    deps_match = re.search(r'ext\.deps\s*=\s*\[(.*?)\n\]\n\n', content, re.DOTALL)
+    if not deps_match:
+        print("Error: Could not locate the ext.deps block.")
+        return
+
+    deps_content = deps_match.group(1)
+
+    # Split the list of maps by the closing bracket pattern "\n\t],"
+    # This safely separates each dictionary without breaking internal lists/closures
+    blocks = deps_content.split('\n\t],')
+
+    results = []
+    for block in blocks:
+        # Clean up any remaining brackets for the very last block in the array
+        block = re.sub(r'\n\t\]$', '', block).strip()
+        if not block:
+            continue
+
+        name_m = re.search(r'name:\s*"([^"]+)"', block)
+        url_m = re.search(r'url:\s*"([^"]+)"', block)
+        sha_m = re.search(r'sha256:\s*"([^"]+)"', block)
+
+        # Match everything after 'destination:' up to the end of the block
+        dest_m = re.search(r'destination:\s*(.*)', block, re.DOTALL)
+
+        if name_m and url_m and sha_m and dest_m:
+            dest = dest_m.group(1).strip()
+
+            # Remove an optional ', eclipse: true' from the end if it exists
+            dest = re.sub(r',\s*eclipse:\s*true\s*$', '', dest, flags=re.DOTALL).strip()
+
+            # Flatten multi-line closures (like the z3 dest blocks) into a single line 
+            # to prevent it from breaking the Markdown table rendering
+            dest_single_line = re.sub(r'\s+', ' ', dest)
+
+            results.append({
+                'name': name_m.group(1),
+                'sha256': sha_m.group(1),
+                'url': url_m.group(1),
+                'destination': dest_single_line
+            })
+
+    if not results:
+        print("No dependencies parsed.")
+        return
+
+    first = True
+    with open(out_file, 'w') as fp:
+        fp.write('[\n')
+        for r in results:
+            if r['name'].startswith('z3'):
+                continue
+
+            url = r['url']
+            if '${RELEASE_VERSION}' in url:
+                if version == '':
+                    continue
+                url = url.replace(r'${RELEASE_VERSION}', version)
+
+            sha = r['sha256']
+
+            dest = r['destination']
+            if dest == 'FLAT_REPO_DIR':
+                dest = 'dependencies/flatRepo'
+            elif dest == 'FID_DIR':
+                dest = 'dependencies/fidb'
+            elif dest.startswith('file("'):
+                dest = dest.replace(r'${DEPS_DIR}', 'dependencies')[6:-2]
+            elif dest.startswith('[file("'):
+                dest = 'dependencies/Debugger-rmi-trace/'
+
+            if not first:
+                fp.write( ',\n')
+            else:
+                first = False
+                fp.write('\n')
+
+            fp.write( '   {\n')
+            fp.write( '       "type": "file",\n')
+            fp.write(f'       "url": "{url}",\n')
+            fp.write(f'       "sha256": "{sha}",\n')
+            fp.write(f'       "dest": "{dest}"\n')
+            fp.write( '   }')
+        fp.write('\n]\n')
+
+def main():
+    logging.basicConfig(
+        level=os.environ.get('LOGLEVEL', 'WARNING').upper()
+    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', help='The fetchDependencies.gradle file')
+    parser.add_argument('output', help='The output JSON sources file')
+    parser.add_argument('--version',
+                        help='The current Ghidra version',
+                        default='')
+
+    args = parser.parse_args()
+
+    extract_dependencies_to_table(args.input, args.output, args.version)
+
+if __name__ == '__main__':
+    main()

--- a/org.ghidra_sre.Ghidra.json
+++ b/org.ghidra_sre.Ghidra.json
@@ -116,85 +116,6 @@
                     "dest": "dex2jar"
                 },
                 {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ee/01/1ed1d482960a5718fd99c82f6d79120181947cfd4667ec3944d448ed44a3/protobuf-6.31.0-py3-none-any.whl",
-                    "sha256": "6ac2e82556e822c17a8d23aa1190bbc1d06efb9c261981da95c71c9da09e9e23",
-                    "dest": "dependencies/Debugger-rmi-trace/"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz",
-                    "sha256": "6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c",
-                    "dest": "dependencies/Debugger-rmi-trace/"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl",
-                    "sha256": "062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
-                    "dest": "dependencies/Debugger-rmi-trace/"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
-                    "sha256": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248",
-                    "dest": "dependencies/Debugger-rmi-trace/"
-                },
-                {
-                    "type": "file",
-                    "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android4me/AXMLPrinter2.jar",
-                    "sha256": "00ed038eb6abaf6ddec8d202a3ed7a81b521458f4cd459948115cfd02ff59d6d",
-                    "dest": "dependencies/flatRepo"
-                },
-                {
-                    "type": "file",
-                    "url": "https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.18/yajsw-stable-13.18.zip",
-                    "sha256": "50b34e9817c54b2970fa511ff4584f6556c179f69833aa8b9b1ff6485b61684f",
-                    "dest": "dependencies/GhidraServer"
-                },
-                {
-                    "type": "file",
-                    "url": "https://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip",
-                    "sha256": "81b7d19d57c4a3009f4761699a72e8d642b5e1d9251d2bb98df438b1e28f8ba9",
-                    "dest": "dependencies/GhidraDev"
-                },
-                {
-                    "type": "file",
-                    "url": "https://sourceforge.net/projects/pydev/files/pydev/PyDev 6.3.1/PyDev 6.3.1.zip",
-                    "sha256": "4d81fe9d8afe7665b8ea20844d3f5107f446742927c59973eade4f29809b0699",
-                    "dest": "dependencies/GhidraDev",
-                    "dest-filename": "PyDev 6.3.1.zip"
-                },
-                {
-                    "type": "file",
-                    "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.0/Debugger/dbgmodel.tlb",
-                    "sha256": "8cf5f3a2eb81160aa349056a5ca4c2c726b1b6e98bf3097cd4135147163343c7",
-                    "dest": "dependencies/Debugger-agent-dbgeng"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ce/78/91db67e7fe1546dc8b02c38591b7732980373d2d252372f7358054031dd4/Pybag-2.2.12-py3-none-any.whl",
-                    "sha256": "eda5ee6c4e873902981b7f525b42a02428b87c7368df2c5bdfe1ded0e6884126",
-                    "dest": "dependencies/Debugger-agent-dbgeng"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d0/dd/b28df50316ca193dd1275a4c47115a720796d9e1501c1888c4bfa5dc2260/capstone-5.0.1-py3-none-win_amd64.whl",
-                    "sha256": "1bfa5c81e6880caf41a31946cd6d2d069c048bcc22edf121254b501a048de675",
-                    "dest": "dependencies/Debugger-agent-dbgeng"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/50/8f/518a37381e55a8857a638afa86143efa5508434613541402d20611a1b322/comtypes-1.4.1-py3-none-any.whl",
-                    "sha256": "a208a0e3ca1c0a5362735da0ff661822801dce87312b894d7d752add010a21b0",
-                    "dest": "dependencies/Debugger-agent-dbgeng"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/83/1c/25b79fc3ec99b19b0a0730cc47356f7e2959863bf9f3cd314332bddb4f68/pywin32-306-cp312-cp312-win_amd64.whl",
-                    "sha256": "37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e",
-                    "dest": "dependencies/Debugger-agent-dbgeng"
-                },
-                {
                     "type": "archive",
                     "url": "https://github.com/Z3Prover/z3/releases/download/z3-4.13.0/z3-4.13.0-x64-glibc-2.31.zip",
                     "sha256": "bc31ad12446d7db1bd9d0ac82dec9d7b5129b8b8dd6e44b571a83ac6010d2f9b",
@@ -207,6 +128,12 @@
                     "dest": "z3-arm64"
                 },
                 {
+                    "type": "file",
+                    "url": "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_12.0/Debugger/dbgmodel.tlb",
+                    "sha256": "8cf5f3a2eb81160aa349056a5ca4c2c726b1b6e98bf3097cd4135147163343c7",
+                    "dest": "dependencies/Debugger-agent-dbgeng"
+                },
+                {
                     "type": "git",
                     "tag": "Ghidra_12.2",
                     "url": "https://github.com/NationalSecurityAgency/ghidra-data.git",
@@ -217,7 +144,8 @@
                         "tag-pattern": "^Ghidra_([\\d.]+)$"
                     }
                 },
-                "gradle-dependencies.json"
+                "gradle-dependencies.json",
+                "gradle-fetched-dependencies.json"
             ]
         }
     ]


### PR DESCRIPTION
Before running the build, Ghidra's gradle/support/fetchDependencies.gradle file fetches a whole lot of dependencies manually. That list has started becoming longer, and updated more often, which means that every Ghidra point release requires a lot of work to manually update packages.

Assisted-by: Gemini:gemini-3.1-pro